### PR TITLE
Make the logit-sigmoid relation explicit

### DIFF
--- a/slides/01/01.md
+++ b/slides/01/01.md
@@ -647,7 +647,7 @@ are parameters of the second layer.
 
   ![w=46%,f=right](sigmoid.svgz)
 
-  $$σ(x) ≝ \frac{1}{1 + e^{-x}}$$
+  $$σ(x) ≝ \frac{1}{1 + e^{-x}} = p$$
   is used to model a probability $p$ of a binary event; its input is called
   a **logit**, $\log \frac{p}{1-p}$;
 


### PR DESCRIPTION
Even though the slides say that the sigmoid models $p$, I think the logit computation is more straightforward if we directly equate $p$ to the sigmoid output.