### PR TITLE
Fix incorrect hint in pca_first.py

### DIFF
--- a/labs/01/pca_first.py
+++ b/labs/01/pca_first.py
@@ -36,7 +36,7 @@ def main(args: argparse.Namespace) -> tuple[float, float]:
     data = ...
 
     # TODO: Now compute mean of every feature. Use `torch.mean`, and set
-    # `axis` to zero -- therefore, the mean will be computed across the first
+    # `dim` to zero -- therefore, the mean will be computed across the first
     # dimension, so across examples.
     mean = ...
 


### PR DESCRIPTION
Pytorch calls the parameter of mean "dim" and not "axis" (unlike numpy, keras).