### PR TITLE
Fix typo in tagger_cle.py

### DIFF
--- a/labs/08/tagger_cle.py
+++ b/labs/08/tagger_cle.py
@@ -246,7 +246,7 @@ class Model(TrainableModule):
         # outputs of forward and backward directions. Also pass `batch_first=True`.
         self._char_rnn = ...
 
-        # TODO:(tagger_we) Create a `torch.nn.Embedding` layer, embedding the form ids
+        # TODO(tagger_we): Create a `torch.nn.Embedding` layer, embedding the form ids
         # from `train.forms.word_vocab` to dimensionality `args.we_dim`.
         self._word_embedding = ...
 


### PR DESCRIPTION
Just a tiny fix to keep the template comments consistent :)