### PR TITLE
Fix tensorboard initialization on Mac

### DIFF
--- a/labs/01/example_pytorch_tensorboard.py
+++ b/labs/01/example_pytorch_tensorboard.py
@@ -64,7 +64,7 @@ def main(args: argparse.Namespace) -> None:
         metrics={"accuracy": torchmetrics.Accuracy("multiclass", num_classes=MNIST.LABELS)},
         logdir=args.logdir,
     )
-    model.get_tb_writer("train").add_graph(model, next(iter(train))[0])
+    model.get_tb_writer("train").add_graph(model, next(iter(train))[0].to(model.device))
 
     # Train the model.
     model.fit(train, dev=dev, epochs=args.epochs)


### PR DESCRIPTION
Running `example_pytorch_tensorboard.py` on a Mac with mps produces error when initializing tensorboard, since the model is loaded to `mps` and the train data are on `cpu`.

This commit fixes the error and should not pose problems on devices with different OS/hardware.