### PR TITLE
Correct Dropout1 to Dropout1d in 07.md

### DIFF
--- a/slides/07/07.md
+++ b/slides/07/07.md
@@ -315,7 +315,7 @@ frequently.
 
 ~~~
 To implement variational dropout on inputs, the same dropout mask must be used
-for all time steps (`torch.nn.Dropout1` in PyTorch; using `noise_shape` in
+for all time steps (`torch.nn.Dropout1d` in PyTorch; using `noise_shape` in
 Keras).
 
 ~~~


### PR DESCRIPTION
The class was incorrectly referred to as `torch.nn.Dropout1`, but the correct name is `torch.nn.Dropout1d`
