### PR TITLE
Fix typo in slides 11

### DIFF
--- a/slides/11/11.md
+++ b/slides/11/11.md
@@ -466,7 +466,7 @@ are negative.
 
 ~~~
 Of course, we need a way to estimate the $v_π(s)$ baseline. The usual approach
-is to approximate it by another neural network model. That a model model is trained
+is to approximate it by another neural network model. That model is trained
 using mean square error of the predicted and observed returns.
 
 ---


### PR DESCRIPTION
Removed reduplicated "model" and a redundant indefinite article.