### PR TITLE
fix: correct typos in lecture notes and GAN task description

### DIFF
--- a/lectures/lecture11.md
+++ b/lectures/lecture11.md
@@ -14,11 +14,11 @@
 
 Study material for Reinforcement Learning is the [Reinforcement Learning: An Introduction; second edition
 by Richard S. Sutton and Andrew G. Barto](http://incompleteideas.net/book/the-book-2nd.html)
-(reffered to as RLB), [available online](http://incompleteideas.net/book/RLbook2020.pdf).
+(referred to as RLB), [available online](http://incompleteideas.net/book/RLbook2020.pdf).
 
 - Multi-armed bandits [Sections 2-2.4 of RLB]
 - Markov Decision Process [Sections 3-3.3 of RLB]
-- Policies and Value Functions [Sections 3.5 of RLB]
+- Policies and Value Functions [Section 3.5 of RLB]
 - Policy Gradient Methods [Sections 13-13.1 of RLB]
 - Policy Gradient Theorem [Section 13.2 of RLB]
 - REINFORCE algorithm [Section 13.3 of RLB]

--- a/tasks/gan.md
+++ b/tasks/gan.md
@@ -4,7 +4,7 @@
 #### Tests: gan_tests
 #### Examples: gan_examples
 
-In this assignment you will implement a simple Generative Adversarion Network
+In this assignment you will implement a simple Generative Adversarial Network
 for three datasets in the MNIST format. Your goal is to modify the
 [gan.py](https://github.com/ufal/npfl138/tree/master/labs/12/gan.py)
 template and implement a GAN.


### PR DESCRIPTION
- `lectures/lecture11.md`
  - "reffered" → "referred"
  - "Sections 3.5" → "Section 3.5"
- `tasks/gan.md`
  - "Generative Adversarion Network" → "Generative Adversarial Network"