### PR TITLE
fix: correct typos in lecture notes

### DIFF
--- a/lectures/lecture02.md
+++ b/lectures/lecture02.md
@@ -20,7 +20,7 @@
   - Backpropagation algorithm [Section 6.5 to 6.5.3 of DLB, especially Algorithms 6.1 and 6.2; _note that Algorithms 6.5 and 6.6 are used in practice_]
   - SGD algorithm [Section 8.3.1 and Algorithm 8.1 of DLB]
   - SGD with Momentum algorithm [Section 8.3.2 and Algorithm 8.2 of DLB]
-  - SGD with Nestorov Momentum algorithm [Section 8.3.3 and Algorithm 8.3 of DLB]
+  - SGD with Nesterov Momentum algorithm [Section 8.3.3 and Algorithm 8.3 of DLB]
   - Optimization algorithms with adaptive gradients
     - AdaGrad algorithm [Section 8.5.1 and Algorithm 8.4 of DLB]
     - RMSProp algorithm [Section 8.5.2 and Algorithm 8.5 of DLB]

--- a/lectures/lecture05.md
+++ b/lectures/lecture05.md
@@ -20,7 +20,7 @@
   - _PyramidNet [[Deep Pyramidal Residual Networks](https://arxiv.org/abs/1610.02915)]_
   - ResNeXt [[Aggregated Residual Transformations for Deep Neural Networks](https://arxiv.org/abs/1611.05431)]
 - Regularizing CNN Networks
-  - DropLayer [[Deep Networks with Stochastic Depth](https://arxiv.org/abs/1603.09382)]
+  - Stochastic Depth [[Deep Networks with Stochastic Depth](https://arxiv.org/abs/1603.09382)]
   - CutOut [[Improved Regularization of Convolutional Neural Networks with Cutout](https://arxiv.org/abs/1708.04552)]
   - DropBlock [[DropBlock: A regularization method for convolutional networks](https://arxiv.org/abs/1810.12890)]
 - SENet [[Squeeze-and-Excitation Networks](https://arxiv.org/abs/1709.01507)]

--- a/lectures/lecture14.md
+++ b/lectures/lecture14.md
@@ -12,5 +12,5 @@
 - Parallel WaveNet [[Parallel WaveNet: Fast High-Fidelity Speech Synthesis](https://arxiv.org/abs/1711.10433)]
 - Tacotron 2 [[Natural TTS Synthesis by Conditioning WaveNet on Mel Spectrogram Predictions](https://arxiv.org/abs/1712.05884)]
 - _FastSpeech [[Fast, Robust and Controllable Text to Speech](https://arxiv.org/abs/1905.09263)]_
-- One TTS Alignment [[One TTS Alignment To Rule Them All]](https://arxiv.org/abs/2108.10447)]
+- One TTS Alignment [[One TTS Alignment To Rule Them All]](https://arxiv.org/abs/2108.10447)
 - _HiFi-GAN, BigVGAN, Vocos, E2-TTS, F5-TTS_


### PR DESCRIPTION
- `lectures/lecture02.md`
  - "Nestorov Momentum" → "Nesterov Momentum"
- `lectures/lecture05.md`
  - "DropLayer" → "Stochastic Depth" (this better reflects the section title: "Deep Networks with Stochastic Depth")
- `lectures/lecture14.md`
  - Removed redundant closing bracket in link for "One TTS Alignment To Rule Them All"
