### PR TITLE
Update flow_matching_attention.py template

### DIFF
--- a/labs/13/flow_matching_attention.py
+++ b/labs/13/flow_matching_attention.py
@@ -111,8 +111,6 @@ class SelfAttentionBlock(torch.nn.Module):
         # TODO: Implement the forward pass of the self-attention block.
         raise NotImplementedError()
 
-        return hidden + inputs
-
 
 class DownscalingBlock(torch.nn.Module):
     """Downscaling block returning both the features of original and downscaled size."""


### PR DESCRIPTION
Removing a probable relict of the reference code. Not that it would be incorrect, it just is not consistent with the rest of the templated NotImplementedError-raising functions.
