### PR TITLE
Slides 07 typo

### DIFF
--- a/slides/07/07.md
+++ b/slides/07/07.md
@@ -403,7 +403,7 @@ during inference) is performed as follows.
 ~~~
 When applying layer normalization after convolutions on an image, we want it to
 be positional invariant (the same as with batch normalization); therefore, we
-have parameters only for channels, i.e., $β ∈ ℝ^C$ and $γ ∈ ℝ^C$, but we compute
+have parameters only for channels, i.e., $→β ∈ ℝ^C$ and $→γ ∈ ℝ^C$, but we compute
 $μ$ and $σ^2$ over the whole image.
 
 ---


### PR DESCRIPTION
LayerNorm parameters should be bold, as they are vectors of size C.