### PR TITLE
fix: typos in npfl138 docs

### DIFF
--- a/labs/npfl138/datasets/cags.py
+++ b/labs/npfl138/datasets/cags.py
@@ -97,7 +97,7 @@ class CAGS:
         """Evaluate the `predictions` labels against the gold dataset.
 
         Returns:
-          accurracy: The average accuracy of the predicted labels in percentages.
+          accuracy: The average accuracy of the predicted labels in percentages.
         """
         gold = [int(example["label"]) for example in gold_dataset]
 
@@ -113,7 +113,7 @@ class CAGS:
         """Evaluate the file with label predictions against the gold dataset.
 
         Returns:
-          accurracy: The average accuracy of the predicted labels in percentages.
+          accuracy: The average accuracy of the predicted labels in percentages.
         """
         predictions = [int(line) for line in predictions_file]
         return CAGS.evaluate_classification(gold_dataset, predictions)

--- a/labs/npfl138/datasets/common_voice_cs.py
+++ b/labs/npfl138/datasets/common_voice_cs.py
@@ -99,7 +99,7 @@ class CommonVoiceCs:
         """Extract MFCC features from an audio tensor.
 
         This function can be used to extract MFCC features from any audio sample,
-        allowing to perform speech recording on any audio sample.
+        allowing to perform speech recognition on any audio sample.
         """
         assert sample_rate == 16_000, "Only 16k sample rate is supported"
 

--- a/labs/npfl138/datasets/reading_comprehension_dataset.py
+++ b/labs/npfl138/datasets/reading_comprehension_dataset.py
@@ -16,7 +16,7 @@
     - `qas`: list of questions and answers, each a dictionary with:
         - `question`: text of the question
         - `answers`: a list of answers, each answer a dictionary containing:
-            - `text`: answer test as string, exactly as appearing in the context
+            - `text`: answer text as string, exactly as appearing in the context
             - `start`: character offset of the answer text in the context
 """
 import os

--- a/labs/npfl138/metrics.py
+++ b/labs/npfl138/metrics.py
@@ -18,7 +18,7 @@ class BIOEncodingF1Score(torch.nn.Module):
 
     - If there is an `I` tag without preceding `B/I` tag, it is considered a `B` tag.
     - If the type of an `I` tag does not match the type of the preceding tag, the type
-      of this `I` tag is ignored (i.e., considered the same as the preceeding tag type).
+      of this `I` tag is ignored (i.e., considered the same as the preceding tag type).
     """
     def __init__(self, labels: list[str], ignore_index: int) -> None:
         """Construct a new BIOEncodingF1Score metric.

--- a/labs/npfl138/rl_utils.py
+++ b/labs/npfl138/rl_utils.py
@@ -16,7 +16,7 @@ import torch
 ############################
 
 class EvaluationEnv(gym.Wrapper):
-    """A wrapper over gym environments capable of performing evaluation on demant.
+    """A wrapper over gym environments capable of performing evaluation on demand.
 
     In addition to a standard gym envrironment, it provides the following features:
 

--- a/labs/npfl138/trainable_module.py
+++ b/labs/npfl138/trainable_module.py
@@ -428,8 +428,8 @@ class TrainableModule(torch.nn.Module):
         """An overridable method performing a single evaluation step, returning the logs.
 
         Parameters:
-        xs: The input batch to the model, either a single tensor or a sequence of tensors.
-        y: The target output batch of the model, either a single tensor or a sequence of tensors.
+          xs: The input batch to the model, either a single tensor or a sequence of tensors.
+          y: The target output batch of the model, either a single tensor or a sequence of tensors.
 
         Returns:
           logs: A dictionary of logs from the evaluation step.


### PR DESCRIPTION
fixed some small typos and wording in `npfl138` package:
* accurracy -> accuracy
* test -> text
* preceeding -> preceding
* demant -> demand
* speech recording -> speech recognition (in `CommonVoiceCs.mfcc_extract()`)
* added indents in `TrainableModule.test_step()` docstring - the documentation for parameters wasn't displayed correctly

