### PR TITLE
SVHN dataset: fix typo in docstring

### DIFF
--- a/labs/npfl138/datasets/svhn.py
+++ b/labs/npfl138/datasets/svhn.py
@@ -74,7 +74,7 @@ class SVHN:
             }
 
     def __init__(self, decode_on_demand: bool = False) -> None:
-        """Load the CAGS dataset, downloading it if necessary."""
+        """Load the SVHN dataset, downloading it if necessary."""
         for dataset, size in [("train", 10_000), ("dev", 1_267), ("test", 4_535)]:
             path = download_url_to_file(self.URL, f"svhn.{dataset}.tfrecord")
             setattr(self, dataset, self.Dataset(path, size, decode_on_demand))


### PR DESCRIPTION
Minor typo I noticed in the web docs (generated).