### PR TITLE
Add ReCodEx mode support with `tagger_ner`

### DIFF
--- a/labs/08/tagger_ner.py
+++ b/labs/08/tagger_ner.py
@@ -144,7 +144,7 @@ class TrainableDataset(npfl138.TransformedDataset):
 
 def main(args: argparse.Namespace) -> dict[str, float]:
     # Set the random seed and the number of threads.
-    npfl138.startup(args.seed, args.threads)
+    npfl138.startup(args.seed, args.threads, args.recodex)
     npfl138.global_keras_initializers()
 
     # Load the data.

--- a/tasks/tagger_ner.md
+++ b/tasks/tagger_ner.md
@@ -29,13 +29,13 @@ must be computed in parallel (vectorized).
 #### Tests Start: tagger_ner_tests
 _Note that your results may be slightly different, depending on your CPU type and whether you use a GPU._
 
-1. `python3 tagger_ner.py --epochs=1 --max_sentences=20 --seed=219`
+1. `python3 tagger_ner.py --recodex --epochs=1 --max_sentences=20 --seed=219`
 ```
 Epoch 1/1 0.1s loss=2.2965 accuracy=0.2418 dev:loss=2.2514 dev:accuracy=0.3271 dev:f1_constrained=0.0269 dev:f1_greedy=0.0359
 ```
 [The optimally decoded tag sequences on the development set](https://ufal.mff.cuni.cz/~straka/courses/npfl138/2526/tasks/figures/tagger_ner.test-1.txt)
 
-2. `python3 tagger_ner.py --epochs=2 --max_sentences=2000 --batch_size=25 --label_smoothing=0.1 --seed=219`
+2. `python3 tagger_ner.py --recodex --epochs=2 --max_sentences=2000 --batch_size=25 --label_smoothing=0.1 --seed=219`
 ```
 Epoch 1/2 3.8s loss=1.5507 accuracy=0.7961 dev:loss=1.2494 dev:accuracy=0.8227 dev:f1_constrained=0.0000 dev:f1_greedy=0.0000
 Epoch 2/2 3.7s loss=1.1968 accuracy=0.8102 dev:loss=1.1583 dev:accuracy=0.8231 dev:f1_constrained=0.0103 dev:f1_greedy=0.0094


### PR DESCRIPTION
This PR adds the missing support for running `tagger_ner.py` in **ReCodEx mode** – by passing the `--recodex` flag to `npfl138.startup()`. This is normally the case with most other assignments (except competitions), but appeared to be accidentally omitted with this assignment.