### PR TITLE
u_t(x|x_t) -> u_t(x|x_1)

### DIFF
--- a/slides/13/13.md
+++ b/slides/13/13.md
@@ -569,13 +569,13 @@ path, we need to check that $p_t$ and $u_t$ satisfy the transport equation:
 $\displaystyle \kern7em{}\mathllap{\tfrac{d}{dt} p_t(→x)} = 𝔼_{→x_1 ∼ p_\textrm{data}}\Big[\tfrac{d}{dt} p_t(→x | →x_1)\Big]$
 
 ~~~
-$\displaystyle \kern7em{} = 𝔼_{→x_1 ∼ p_\textrm{data}}\Big[-\operatorname{div}\big(u_t(→x | →x_t) p_t(→x | →x_1)\big)\Big]$
+$\displaystyle \kern7em{} = 𝔼_{→x_1 ∼ p_\textrm{data}}\Big[-\operatorname{div}\big(u_t(→x | →x_1) p_t(→x | →x_1)\big)\Big]$
 
 ~~~
-$\displaystyle \kern7em{} = -\operatorname{div}\Big(𝔼_{→x_1 ∼ p_\textrm{data}}\big[u_t(→x | →x_t) p_t(→x | →x_1)\big]\Big)$
+$\displaystyle \kern7em{} = -\operatorname{div}\Big(𝔼_{→x_1 ∼ p_\textrm{data}}\big[u_t(→x | →x_1) p_t(→x | →x_1)\big]\Big)$
 
 ~~~
-$\displaystyle \kern7em{} = -\operatorname{div}\Big(\underbrace{𝔼_{→x_1 ∼ p_\textrm{data}}\big[u_t(→x | →x_t) p_t(→x | →x_1)\textcolor{blue}{/p_t(→x)}\big]}_{\textrm{definition~of~}u_t(→x)}\textcolor{blue}{p_t(→x)}\Big)$
+$\displaystyle \kern7em{} = -\operatorname{div}\Big(\underbrace{𝔼_{→x_1 ∼ p_\textrm{data}}\big[u_t(→x | →x_1) p_t(→x | →x_1)\textcolor{blue}{/p_t(→x)}\big]}_{\textrm{definition~of~}u_t(→x)}\textcolor{blue}{p_t(→x)}\Big)$
 
 ~~~
 $\displaystyle \kern7em{} = -\operatorname{div}\big(u_t(→x)p_t(→x)\big).$


### PR DESCRIPTION
While I am not 100% certain, I believe that [lecture 13 slide 31](https://ufal.mff.cuni.cz/~straka/courses/npfl138/2526/slides/?13#31) should say $u_t(x|x_1)$ instead of $u_t(x|x_t)$.

The reasons being:
- We do not actually define $x_t$ anywhere (or use it anywhere else).
- The definition of $u_t(x)$, which we are referencing in that slide, uses $x_1$ rather than $x_t$.
- Also just makes sense to me.

Cheers,
Filip