### PR TITLE
Theta -> theta

### DIFF
--- a/slides/13/13.md
+++ b/slides/13/13.md
@@ -621,7 +621,7 @@ $$\begin{aligned}
   𝓛_\textrm{CFM}(→θ) &≝ 𝔼_{t, →x_1 ∼ p_\textrm{data}, →x ∼ p_t(→x|→x_1)} \|v_t(→x; →θ) - u_t(→x | →x_1)\|^2 \\
 \end{aligned}$$
 
-To show that the gradients $∇_{→Θ}$ of $𝓛_\textrm{FM}$ and $𝓛_\textrm{CFM}$ are
+To show that the gradients $∇_{→θ}$ of $𝓛_\textrm{FM}$ and $𝓛_\textrm{CFM}$ are
 the same, we start with:
 
 ~~~


### PR DESCRIPTION
I'm bringing another one 😄. Again I am not 100% certain, but it seems like the theta was capitalized in the gradient by accident.