### PR TITLE
TODO -> TODO(flow_matching)

### DIFF
--- a/labs/13/flow_matching_attention.py
+++ b/labs/13/flow_matching_attention.py
@@ -188,7 +188,7 @@ class UNet(torch.nn.Module):
     """The U-Net architecture used in the flow matching model."""
     def __init__(self, channels: int, stage_blocks: int, stages: int, attention_stages: int, attention_heads: int):
         super().__init__()
-        # TODO: When processing the input images and the input times, start by
+        # TODO(flow_matching): When processing the input images and the input times, start by
         # passing the times through the `SinusoidalEmbedding` layer with
         # dimension of `channels`; the result is then passed to all later layers
         # that require the time embedding.


### PR DESCRIPTION
When I was doing this task, I felt a bit confused because the TODO seemed to be the same as in `flow_matching.py`, but didn't say `TODO(flow_matching)`, so I had to check if anything changed. Because the next TODO asks us to modify the contents of this TODO, I think it's clearer if this one says `TODO(flow_matching)`.