### PR TITLE
Fix typos in tacotron templates and slides

### DIFF
--- a/labs/14/tacotron.py
+++ b/labs/14/tacotron.py
@@ -65,7 +65,7 @@ class Encoder(torch.nn.Module):
         super().__init__()
         # TODO: Create the required encoder layers. The architecture of the encoder is as follows:
         # - Convert the texts to embeddings using `torch.nn.Embedding(num_characters, args.encoder_dim)`.
-        # - Pass the result throught a `torch.nn.Dropout(args.dropout)` layer.
+        # - Pass the result through a `torch.nn.Dropout(args.dropout)` layer.
         # - After moving the channels to the front (i.e., dim=1), pass the result through
         #   `args.encoder_layers` number of layers, each consisting of
         #   - 1D convolution with `args.encoder_dim` channels, kernel size 5, padding 2, and no bias,
@@ -188,7 +188,7 @@ class Decoder(torch.nn.Module):
     def forward(self, context: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         # TODO: Implement a single step of the decoder.
         #
-        # - First run the `self.decoder` on the concatenation the stored next decoder input and
+        # - First run the `self.decoder` on the concatenation of the stored next decoder input and
         #   the given context vector, using and updating the stored decoder RNN state and memory cell values.
         # - Then pass the computed decoder RNN state through the `self.output_layer` to obtain
         #   the predicted `mel_frame` for the current step.

--- a/labs/14/tacotron_aligned.py
+++ b/labs/14/tacotron_aligned.py
@@ -65,7 +65,7 @@ class Encoder(torch.nn.Module):
         super().__init__()
         # TODO(tacotron): Create the required encoder layers. The architecture of the encoder is as follows:
         # - Convert the texts to embeddings using `torch.nn.Embedding(num_characters, args.encoder_dim)`.
-        # - Pass the result throught a `torch.nn.Dropout(args.dropout)` layer.
+        # - Pass the result through a `torch.nn.Dropout(args.dropout)` layer.
         # - After moving the channels to the front (i.e., dim=1), pass the result through
         #   `args.encoder_layers` number of layers, each consisting of
         #   - 1D convolution with `args.encoder_dim` channels, kernel size 5, padding 2, and no bias,
@@ -188,7 +188,7 @@ class Decoder(torch.nn.Module):
     def forward(self, context: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         # TODO(tacotron): Implement a single step of the decoder.
         #
-        # - First run the `self.decoder` on the concatenation the stored next decoder input and
+        # - First run the `self.decoder` on the concatenation of the stored next decoder input and
         #   the given context vector, using and updating the stored decoder RNN state and memory cell values.
         # - Then pass the computed decoder RNN state through the `self.output_layer` to obtain
         #   the predicted `mel_frame` for the current step.

--- a/slides/14/14.md
+++ b/slides/14/14.md
@@ -640,7 +640,7 @@ cell state. However, in this model, it is beneficial for the attention to have
 access to the generated spectrogram.
 
 ~~~
-Therefore, a separate _attention RNN_ is used, which has to goal to represent
+Therefore, a separate _attention RNN_ is used, which has a goal to represent
 the “mel spectrogram generated so far”: its inputs are the decoder input
 (the result of the pre-net) concatenated with the attention context vector
 $→α_i^\T →h$, and the output of this attention RNN is used as $→s_{i-1}$ in the


### PR DESCRIPTION
Fixing minor typos in labs/14 templates `tacotron.py` and `tacotron_aligned.py`

Furthermore, fixing a typo in `slides/14/14.md` in the most straightforward manner:
- "which has to goal to" --> "which has a goal to"
although I am sure that a fancier (and perhaps more appropriate) wording is possible, e.g. "a goal of which is to"
